### PR TITLE
Remove fetch limit on cards

### DIFF
--- a/api/card/services/Card.js
+++ b/api/card/services/Card.js
@@ -38,7 +38,7 @@ module.exports = {
       .where(convertedParams.where)
       .sort(convertedParams.sort)
       .skip(convertedParams.start)
-      .limit(convertedParams.limit)
+      // .limit(convertedParams.limit)
       .populate(
           _.keys(
               _.groupBy(


### PR DESCRIPTION
Removing a "bug" that limits the number of cards fetched to 100. This is a problem with the current set up that depends on all cards being fetched at once. A likely solution would be to utilize a pagination system. 